### PR TITLE
fix: update package git URLs and versions

### DIFF
--- a/.dart_tool/package_graph.json
+++ b/.dart_tool/package_graph.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "geometry_kit",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": [],
       "devDependencies": [
         "lints",

--- a/packages/geometry_kit/CHANGELOG.md
+++ b/packages/geometry_kit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- update git hub info
+
 ## 1.2.1
 
 - **fix:** `Line` — tightened NaN checks across slope/intercept calculations

--- a/packages/geometry_kit/pubspec.yaml
+++ b/packages/geometry_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: geometry_kit
 description: A set of utils that help with geometry (line, circle, triangle, polygon, arc, ring, capsule, bezier, spline, ellipse, rectangle, ray).
-version: 1.2.1
+version: 1.2.2
 
 homepage: http://github.com/samderlust/geometry_kit/tree/main/packages/geometry_kit
 repository: https://github.com/samderlust/geometry_kit

--- a/packages/geometry_kit/pubspec.yaml
+++ b/packages/geometry_kit/pubspec.yaml
@@ -2,9 +2,9 @@ name: geometry_kit
 description: A set of utils that help with geometry (line, circle, triangle, polygon, arc, ring, capsule, bezier, spline, ellipse, rectangle, ray).
 version: 1.2.1
 
-homepage: https://github.com/samderlust/geometry_kits_mono/tree/main/packages/geometry_Kit
-repository: https://github.com/samderlust/geometry_kits_mono
-issue_tracker: https://github.com/samderlust/geometry_kits_mono/issues
+homepage: http://github.com/samderlust/geometry_kit/tree/main/packages/geometry_kit
+repository: https://github.com/samderlust/geometry_kit
+issue_tracker: https://github.com/samderlust/geometry_kit/issues
 
 topics:
   - geometry

--- a/packages/geometry_kit_widgets/CHANGELOG.md
+++ b/packages/geometry_kit_widgets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- update git info
+
 ## 0.1.0
 
 Initial release. Phase 1 of the widget library.

--- a/packages/geometry_kit_widgets/pubspec.yaml
+++ b/packages/geometry_kit_widgets/pubspec.yaml
@@ -1,10 +1,10 @@
 name: geometry_kit_widgets
 description: Flutter widgets for geometry_kit shapes — CustomPainter-backed, styled, themable, and composable. Includes circle, ellipse, rectangle, triangle, polygon, line, and a multi-shape canvas.
-version: 0.1.0
+version: 0.1.1
 
-homepage: https://github.com/samderlust/geometry_kits_mono/tree/main/packages/geometry_kit_widgets
-repository: https://github.com/samderlust/geometry_kits_mono
-issue_tracker: https://github.com/samderlust/geometry_kits_mono/issues
+homepage: http://github.com/samderlust/geometry_kit/tree/main/packages/geometry_kit_widgets
+repository: https://github.com/samderlust/geometry_kit
+issue_tracker: https://github.com/samderlust/geometry_kit/issues
 
 topics:
   - geometry


### PR DESCRIPTION
## Summary

- Update `geometry_kit` version 1.2.1 → 1.2.2
- Update `geometry_kit_widgets` version 0.1.0 → 0.1.1
- Fix GitHub repository URLs to point to `geometry_kit` repo instead of `geometry_kits_mono`
- Update CHANGELOGs for both packages